### PR TITLE
hide conversationDiv in starting

### DIFF
--- a/complete/src/main/resources/static/index.html
+++ b/complete/src/main/resources/static/index.html
@@ -27,7 +27,9 @@
         }
         
         function disconnect() {
-            stompClient.disconnect();
+            if (stompClient != null) {
+                stompClient.disconnect();
+            }
             setConnected(false);
             console.log("Disconnected");
         }
@@ -46,7 +48,7 @@
         }
     </script>
 </head>
-<body>
+<body onload="disconnect()">
 <noscript><h2 style="color: #ff0000">Seems your browser doesn't support Javascript! Websocket relies on Javascript being enabled. Please enable
     Javascript and reload this page!</h2></noscript>
 <div>


### PR DESCRIPTION
Currently, when accessing /index.html for the first time, conversationDiv appears. This shouldn't be visible until pressing connect button.