### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,11 @@
 :spring_version: current
 :spring_boot_version: 1.5.10.RELEASE
-:jackson: http://wiki.fasterxml.com/JacksonHome
-:AtMessageMapping: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/messaging/handler/annotation/MessageMapping.html
-:AtController: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:AtEnableWebSocketMessageBroker: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/messaging/simp/config/EnableWebSocketMessageBroker.html
+:jackson: https://wiki.fasterxml.com/JacksonHome
+:AtMessageMapping: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/messaging/handler/annotation/MessageMapping.html
+:AtController: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
+:AtEnableWebSocketMessageBroker: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/messaging/simp/config/EnableWebSocketMessageBroker.html
 :Stomp_JS: http://jmesnil.net/stomp-websocket/doc/
-:AtSendTo: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/messaging/handler/annotation/SendTo.html
+:AtSendTo: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/messaging/handler/annotation/SendTo.html
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -13,7 +13,7 @@
 
 This guide walks you through the process of creating a "hello world" application that sends messages back and forth, between a browser and the server.
 WebSocket is a very thin, lightweight layer above TCP. It makes it very suitable to use "subprotocols" to embed messages. In this
-guide we'll dive in and use http://en.wikipedia.org/wiki/Streaming_Text_Oriented_Messaging_Protocol[STOMP] messaging with Spring
+guide we'll dive in and use https://en.wikipedia.org/wiki/Streaming_Text_Oriented_Messaging_Protocol[STOMP] messaging with Spring
 to create an interactive web application.
 
 == What you'll build


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://jmesnil.net/stomp-websocket/doc/ (200) with 1 occurrences could not be migrated:  
   ([https](https://jmesnil.net/stomp-websocket/doc/) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://wiki.fasterxml.com/JacksonHome (UnknownHostException) with 1 occurrences migrated to:  
  https://wiki.fasterxml.com/JacksonHome ([https](https://wiki.fasterxml.com/JacksonHome) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring/docs/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://en.wikipedia.org/wiki/Streaming_Text_Oriented_Messaging_Protocol with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Streaming_Text_Oriented_Messaging_Protocol ([https](https://en.wikipedia.org/wiki/Streaming_Text_Oriented_Messaging_Protocol) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences