### PR TITLE
Update dependencies versions

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -28,22 +28,22 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>sockjs-client</artifactId>
-			<version>1.0.2</version>
+			<version>1.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>stomp-websocket</artifactId>
-			<version>2.3.3</version>
+			<version>2.3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>3.3.7</version>
+			<version>5.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>jquery</artifactId>
-			<version>3.1.1-1</version>
+			<version>3.6.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Update dependencies versions for:
- sockjs-client: FROM 1.0.2 (Jul 29, 2015) TO 1.5.1 (Apr 08, 2021)
- stomp-websocket: FROM 2.3.3 (Apr 01, 2015) TO 2.3.4 (Apr 08, 2021)
- bootstrap: FROM 3.3.7 (Jul 25, 2016) TO 5.2.2 (Oct 04, 2022)
- jquery: FROM 3.1.1-1 (Dec 09, 2016) TO 3.6.1 (Aug 31, 2022)