### PR TITLE
Update dependencies versions

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -15,10 +15,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.webjars:webjars-locator-core'
-	implementation 'org.webjars:sockjs-client:1.0.2'
-	implementation 'org.webjars:stomp-websocket:2.3.3'
-	implementation 'org.webjars:bootstrap:3.3.7'
-	implementation 'org.webjars:jquery:3.1.1-1'
+	implementation 'org.webjars:sockjs-client:1.5.1'
+	implementation 'org.webjars:stomp-websocket:2.3.4'
+	implementation 'org.webjars:bootstrap:5.2.2'
+	implementation 'org.webjars:jquery:3.6.1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 


### PR DESCRIPTION
Update dependencies versions for the implementations:
- sockjs-client: FROM 1.0.2 (Jul 29, 2015) TO 1.5.1 (Apr 08, 2021)
- stomp-websocket: FROM 2.3.3 (Apr 01, 2015) TO 2.3.4 (Apr 08, 2021)
- bootstrap: FROM 3.3.7 (Jul 25, 2016) TO 5.2.2 (Oct 04, 2022)
- jquery: FROM 3.1.1-1 (Dec 09, 2016) TO 3.6.1 (Aug 31, 2022)