### PR TITLE
Upgrading Stomp client dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,72 +47,7 @@ NOTE: If your IDE has the Spring Initializr integration, you can complete this p
 
 NOTE: You can also fork the project from Github and open it in your IDE or other editor.
 
-== Adding Dependencies
-
-The Spring Initializr does not provide everything you need in this case. For Maven, you
-need to add the following dependencies:
-
-====
-[source,xml]
-----
-<dependency>
-  <groupId>org.webjars</groupId>
-  <artifactId>webjars-locator-core</artifactId>
-</dependency>
-<dependency>
-  <groupId>org.webjars</groupId>
-  <artifactId>sockjs-client</artifactId>
-  <version>1.0.2</version>
-</dependency>
-<dependency>
-  <groupId>org.webjars</groupId>
-  <artifactId>stomp-websocket</artifactId>
-  <version>2.3.3</version>
-</dependency>
-<dependency>
-  <groupId>org.webjars</groupId>
-  <artifactId>bootstrap</artifactId>
-  <version>3.3.7</version>
-</dependency>
-<dependency>
-  <groupId>org.webjars</groupId>
-  <artifactId>jquery</artifactId>
-  <version>3.1.1-1</version>
-</dependency>
-----
-====
-
-The following listing shows the finished `pom.xml` file:
-
-====
-[src,xml]
-----
-include::complete/pom.xml[]
-----
-====
-
-If you use Gradle, you need to add the following dependencies:
-
-====
-[source,java]
-----
-implementation 'org.webjars:webjars-locator-core'
-implementation 'org.webjars:sockjs-client:1.0.2'
-implementation 'org.webjars:stomp-websocket:2.3.3'
-implementation 'org.webjars:bootstrap:3.3.7'
-implementation 'org.webjars:jquery:3.1.1-1'
-----
-====
-
-The following listing shows the finished `build.gradle` file:
-
-====
-[src,java]
-----
-include::complete/build.gradle[]
-----
-====
-
+===
 [[initial]]
 == Create a Resource Representation Class
 
@@ -240,10 +175,7 @@ designates the `/app` prefix for messages that are bound for methods annotated w
 example, `/app/hello` is the endpoint that the `GreetingController.greeting()` method is
 mapped to handle.
 
-The `registerStompEndpoints()` method registers the `/gs-guide-websocket` endpoint,
-enabling SockJS fallback options so that alternate transports can be used if WebSocket is
-not available. The SockJS client will attempt to connect to `/gs-guide-websocket` and use
-the best available transport (websocket, xhr-streaming, xhr-polling, and so on).
+The `registerStompEndpoints()` method registers the `/gs-guide-websocket` endpoint for websockets' connections.
 
 == Create a Browser Client
 
@@ -260,7 +192,7 @@ include::complete/src/main/resources/static/index.html[]
 ----
 ====
 
-This HTML file imports the `SockJS` and `STOMP` javascript libraries that will be used to
+This HTML file imports the `STOMPJS` javascript library that will be used to
 communicate with our server through STOMP over websocket. We also import `app.js`, which
 contains the logic of our client application. The following listing (from
 `src/main/resources/static/app.js`) shows that file:
@@ -272,11 +204,11 @@ include::complete/src/main/resources/static/app.js[]
 ----
 ====
 
-The main pieces of this JavaScript file to understand are the `connect()` and `sendName()`
+The main pieces of this JavaScript file to understand are the `stompClient.onConnect` and `sendName`
 functions.
 
-The `connect()` function uses https://github.com/sockjs[SockJS] and {Stomp_JS}[stomp.js]
-to open a connection to `/gs-guide-websocket`, which is where our SockJS server waits for
+`stompClient` is initialized with `brokerURL` referring to path `/gs-guide-websocket`,
+which is where our websockets server waits for
 connections. Upon a successful connection, the client subscribes to the `/topic/greetings`
 destination, where the server will publish greeting messages. When a greeting is received
 on that destination, it will append a paragraph element to the DOM to display the greeting
@@ -330,6 +262,7 @@ Congratulations! You have just developed a STOMP-based messaging service with Sp
 
 The following guides may also be helpful:
 
+* https://stomp-js.github.io/[StompJS client library docs]
 * https://spring.io/guides/gs/serving-web-content/[Serving Web Content with Spring MVC]
 * https://spring.io/guides/gs/spring-boot/[Building an Application with Spring Boot]
 

--- a/README.adoc
+++ b/README.adoc
@@ -175,7 +175,7 @@ designates the `/app` prefix for messages that are bound for methods annotated w
 example, `/app/hello` is the endpoint that the `GreetingController.greeting()` method is
 mapped to handle.
 
-The `registerStompEndpoints()` method registers the `/gs-guide-websocket` endpoint for websockets' connections.
+The `registerStompEndpoints()` method registers the `/gs-guide-websocket` endpoint for websocket connections.
 
 == Create a Browser Client
 
@@ -192,7 +192,7 @@ include::complete/src/main/resources/static/index.html[]
 ----
 ====
 
-This HTML file imports the `STOMPJS` javascript library that will be used to
+This HTML file imports the https://stomp-js.github.io/[`StompJS`] javascript library that will be used to
 communicate with our server through STOMP over websocket. We also import `app.js`, which
 contains the logic of our client application. The following listing (from
 `src/main/resources/static/app.js`) shows that file:

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -14,11 +14,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.webjars:webjars-locator-core'
-	implementation 'org.webjars:sockjs-client:1.0.2'
-	implementation 'org.webjars:stomp-websocket:2.3.3'
-	implementation 'org.webjars:bootstrap:3.3.7'
-	implementation 'org.webjars:jquery:3.1.1-1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -22,31 +22,6 @@
 			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>webjars-locator-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>sockjs-client</artifactId>
-			<version>1.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>stomp-websocket</artifactId>
-			<version>2.3.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>bootstrap</artifactId>
-			<version>3.3.7</version>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>jquery</artifactId>
-			<version>3.1.1-1</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/complete/src/main/java/com/example/messagingstompwebsocket/WebSocketConfig.java
+++ b/complete/src/main/java/com/example/messagingstompwebsocket/WebSocketConfig.java
@@ -18,7 +18,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
-		registry.addEndpoint("/gs-guide-websocket").withSockJS();
+		registry.addEndpoint("/gs-guide-websocket");
 	}
 
 }

--- a/complete/src/main/resources/static/app.js
+++ b/complete/src/main/resources/static/app.js
@@ -1,4 +1,26 @@
-var stompClient = null;
+const stompClient = new StompJs.Client({
+    brokerURL: 'ws://localhost:8080/gs-guide-websocket',
+    reconnectDelay: 5000,
+    heartbeatIncoming: 4000,
+    heartbeatOutgoing: 4000
+});
+
+stompClient.onConnect = (frame) => {
+    setConnected(true);
+    console.log('Connected: ' + frame);
+    stompClient.subscribe('/topic/greetings', (greeting) => {
+        showGreeting(JSON.parse(greeting.body).content);
+    });
+};
+
+stompClient.onWebSocketError = (error) => {
+    console.error('Error with websocket', error);
+};
+
+stompClient.onStompError = (frame) => {
+    console.error('Broker reported error: ' + frame.headers['message']);
+    console.error('Additional details: ' + frame.body);
+};
 
 function setConnected(connected) {
     $("#connect").prop("disabled", connected);
@@ -13,27 +35,20 @@ function setConnected(connected) {
 }
 
 function connect() {
-    var socket = new SockJS('/gs-guide-websocket');
-    stompClient = Stomp.over(socket);
-    stompClient.connect({}, function (frame) {
-        setConnected(true);
-        console.log('Connected: ' + frame);
-        stompClient.subscribe('/topic/greetings', function (greeting) {
-            showGreeting(JSON.parse(greeting.body).content);
-        });
-    });
+    stompClient.activate();
 }
 
 function disconnect() {
-    if (stompClient !== null) {
-        stompClient.disconnect();
-    }
+    stompClient.deactivate();
     setConnected(false);
     console.log("Disconnected");
 }
 
 function sendName() {
-    stompClient.send("/app/hello", {}, JSON.stringify({'name': $("#name").val()}));
+    stompClient.publish({
+        destination: "/app/hello",
+        body: JSON.stringify({'name': $("#name").val()})
+    });
 }
 
 function showGreeting(message) {
@@ -41,11 +56,9 @@ function showGreeting(message) {
 }
 
 $(function () {
-    $("form").on('submit', function (e) {
-        e.preventDefault();
-    });
-    $( "#connect" ).click(function() { connect(); });
-    $( "#disconnect" ).click(function() { disconnect(); });
-    $( "#send" ).click(function() { sendName(); });
+    $("form").on('submit', (e) => e.preventDefault());
+    $( "#connect" ).click(() => connect());
+    $( "#disconnect" ).click(() => disconnect());
+    $( "#send" ).click(() => sendName());
 });
 

--- a/complete/src/main/resources/static/index.html
+++ b/complete/src/main/resources/static/index.html
@@ -2,11 +2,10 @@
 <html>
 <head>
     <title>Hello WebSocket</title>
-    <link href="/webjars/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link href="/main.css" rel="stylesheet">
-    <script src="/webjars/jquery/jquery.min.js"></script>
-    <script src="/webjars/sockjs-client/sockjs.min.js"></script>
-    <script src="/webjars/stomp-websocket/stomp.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
     <script src="/app.js"></script>
 </head>
 <body>

--- a/complete/src/test/java/com/example/messagingstompwebsocket/GreetingIntegrationTests.java
+++ b/complete/src/test/java/com/example/messagingstompwebsocket/GreetingIntegrationTests.java
@@ -21,9 +21,9 @@ import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandler;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.WebSocketClient;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
-import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,8 +34,6 @@ public class GreetingIntegrationTests {
 	@Value(value="${local.server.port}")
 	private int port;
 
-	private SockJsClient sockJsClient;
-
 	private WebSocketStompClient stompClient;
 
 	private final WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
@@ -43,10 +41,11 @@ public class GreetingIntegrationTests {
 	@BeforeEach
 	public void setup() {
 		List<Transport> transports = new ArrayList<>();
-		transports.add(new WebSocketTransport(new StandardWebSocketClient()));
-		this.sockJsClient = new SockJsClient(transports);
+		WebSocketClient webSocketClient = new StandardWebSocketClient();
+		transports.add(new WebSocketTransport(webSocketClient));
 
-		this.stompClient = new WebSocketStompClient(sockJsClient);
+		this.stompClient = new WebSocketStompClient(webSocketClient);
+		this.stompClient = new WebSocketStompClient(webSocketClient);
 		this.stompClient.setMessageConverter(new MappingJackson2MessageConverter());
 	}
 


### PR DESCRIPTION
Spring's [websockets tutorial](https://spring.io/guides/gs/messaging-stomp-websocket/) currently uses the [stomp-websocket](https://www.npmjs.com/package/stomp-websocket) client library, which is not maintained anymore (last release 5 years ago).

This pull request updates the tutorial to use [stomp-js](https://github.com/stomp-js/stompjs), which is currently maintained and has plus 100K weekly downloads in npm.

[StompJs's docs](https://stomp-js.github.io/guide/stompjs/rx-stomp/using-stomp-with-sockjs.html) recommends explicitly not to use SockJs, unless you really need to support an old browser. That's why the SockJs setup was removed from the tutorial.

Something else that was changed is to get the Javascript dependencies directly in the html from CDNs.

Please let me know if the PR is welcome and if you would like any change before moving forwards.

Thanks in advance!

With kind regards,
Márcio

